### PR TITLE
Prepare chunks to meet new specs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -79,11 +79,23 @@ export default class OasisApp {
     }
   }
 
-  static prepareChunks(serializedPathBuffer, contextBuffer, contextSizeBuffer, messageBuffer) {
+  static prepareChunks(serializedPathBuffer, context, message) {
     const chunks = [];
 
     // First chunk (only path)
     chunks.push(serializedPathBuffer);
+
+    const contextSizeBuffer = Buffer.from([context.length])
+    const contextBuffer = Buffer.from(context)
+    const messageBuffer = Buffer.from(message)
+
+    if (context.length > 255) {
+      throw new Error("Maximum supported context size is 255 bytes");
+    }
+
+    if (contextSizeBuffer.length > 1) {
+      throw new Error("Context size buffer should be exacty 1 byte");
+    }
 
     // Now split context length + context + message into more chunks
     const buffer = Buffer.concat([contextSizeBuffer, contextBuffer, messageBuffer]);
@@ -101,7 +113,8 @@ export default class OasisApp {
   async signGetChunks(path, context, message) {
 
     const serializedPath = await this.serializePath(path);
-    return prepareChunks(serializedPath, Buffer.from(context), Buffer.from([context.length]), Buffer.from(message))
+
+    return prepareChunks(serializedPath, context, message)
 
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -79,17 +79,14 @@ export default class OasisApp {
     }
   }
 
-  async signGetChunks(path, context, message) {
+  static prepareChunks(serializedPathBuffer, contextBuffer, contextSizeBuffer, messageBuffer) {
     const chunks = [];
 
-    // First chunk
-    const serializedPath = await this.serializePath(path);
-    const contextSize = Buffer.from([context.length]);
-    const firstChunk = Buffer.concat([serializedPath, contextSize, Buffer.from(context)]);
-    chunks.push(firstChunk);
+    // First chunk (only path)
+    chunks.push(serializedPathBuffer);
 
-    // Now split message into more chunks
-    const buffer = Buffer.from(message);
+    // Now split context length + context + message into more chunks
+    const buffer = Buffer.concat([contextSizeBuffer, contextBuffer, messageBuffer]);
     for (let i = 0; i < buffer.length; i += CHUNK_SIZE) {
       let end = i + CHUNK_SIZE;
       if (i > buffer.length) {
@@ -99,6 +96,13 @@ export default class OasisApp {
     }
 
     return chunks;
+  }
+
+  async signGetChunks(path, context, message) {
+
+    const serializedPath = await this.serializePath(path);
+    return prepareChunks(serializedPath, Buffer.from(context), Buffer.from([context.length]), Buffer.from(message))
+
   }
 
   async getVersion() {

--- a/tests/basic.spec.js
+++ b/tests/basic.spec.js
@@ -17,12 +17,42 @@ test("check prepare chunks function", async () => {
         "83CWt4ZmVyX3Rva2Vuc0Blbm9uY2UAZm1ldGhvZHBzdGFraW5nLlRyYW5zZmVy",
       "base64",
     );
-  const contextSize = Buffer.from([context.length]);
 
-  const chunks = OasisApp.prepareChunks(serializedPath, contextSize, Buffer.from(context) , message);
+  const chunks = OasisApp.prepareChunks(serializedPath, context, message);
 
   // Expect first chunk to be path
   expect(chunks[0]).toEqual(serializedPath);
   // First chunk should be path and second should have context + message so at least 2 chunks
   expect(chunks.length).toBeGreaterThan(1);
+});
+
+test("Verify prepare chunk function with empty context", async () => {
+  const serializedPath = serializePathv1([44, 123, 5, 0, 3]);
+  const message = Buffer.from(
+      "pGNmZWWiY2dhcwBmYW1vdW50QGRib2R5omd4ZmVyX3RvWCBkNhaFWEyIEubmS3EVtRLTanD3U+vDV5fke4Obyq" +
+        "83CWt4ZmVyX3Rva2Vuc0Blbm9uY2UAZm1ldGhvZHBzdGFraW5nLlRyYW5zZmVy",
+      "base64",
+    );
+  const context = '';
+
+  const chunks = OasisApp.prepareChunks(serializedPath, context, message);
+
+  // First byte should be 0 (length of context)
+  expect(chunks[1][0]).toEqual(0x00);
+});
+
+test("Test prepareChunks with context bigger than 255 bytes", async () => {
+  const serializedPath = serializePathv1([44, 123, 5, 0, 3]);
+  const message = Buffer.from(
+      "pGNmZWWiY2dhcwBmYW1vdW50QGRib2R5omd4ZmVyX3RvWCBkNhaFWEyIEubmS3EVtRLTanD3U+vDV5fke4Obyq" +
+        "83CWt4ZmVyX3Rva2Vuc0Blbm9uY2UAZm1ldGhvZHBzdGFraW5nLlRyYW5zZmVy",
+      "base64",
+    );
+  const context = 'A'.repeat(256);
+
+  try {
+    const chunks = OasisApp.prepareChunks(serializedPath, context, message);
+  } catch (e) {
+    expect(e).toEqual(new Error("Maximum supported context size is 255 bytes"));
+  }
 });

--- a/tests/basic.spec.js
+++ b/tests/basic.spec.js
@@ -1,8 +1,28 @@
 import OasisApp from "index.js";
+import { serializePathv1 } from "../src/helperV1";
+
+const context = "oasis-core/consensus: tx for chain testing";
 
 test("check address conversion", async () => {
   const pkStr = "17483e0883cf71e2fe4e12f42d1448d06f4274a73b9b6f560c5ed01a32745276";
   const pk = Buffer.from(pkStr, "hex");
   const addr = OasisApp.getBech32FromPK(pk);
   expect(addr).toEqual("oasis1zayruzyreac79ljwzt6z69zg6ph5ya988wdk74svtmgp5vn52fmqg7uz69");
+});
+
+test("check prepare chunks function", async () => {
+  const serializedPath = serializePathv1([44, 123, 5, 0, 3]);
+  const message = Buffer.from(
+      "pGNmZWWiY2dhcwBmYW1vdW50QGRib2R5omd4ZmVyX3RvWCBkNhaFWEyIEubmS3EVtRLTanD3U+vDV5fke4Obyq" +
+        "83CWt4ZmVyX3Rva2Vuc0Blbm9uY2UAZm1ldGhvZHBzdGFraW5nLlRyYW5zZmVy",
+      "base64",
+    );
+  const contextSize = Buffer.from([context.length]);
+
+  const chunks = OasisApp.prepareChunks(serializedPath, contextSize, Buffer.from(context) , message);
+
+  // Expect first chunk to be path
+  expect(chunks[0]).toEqual(serializedPath);
+  // First chunk should be path and second should have context + message so at least 2 chunks
+  expect(chunks.length).toBeGreaterThan(1);
 });


### PR DESCRIPTION
Added a `prepareChunks` static function which store in the first chunk the path and in the rest the context + message.

Closes #1 

Also added unit test for it.